### PR TITLE
Add tests for engine utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for tests."""
+
+import os
+import sys
+
+# Ensure the repository root is on sys.path so ``Engine`` can be imported
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,0 @@
-# tests/test_placeholders.py
-from ...Engine.Core.placeholders import resolve_placeholders
-
-def test_resolve_nested():
-    ctx = {"A": {"B": 1}}
-    assert resolve_placeholders("{{A.B}}", ctx) == "1"
-    assert resolve_placeholders("x{{A.B}}y", ctx) == "x1y"

--- a/tests/test_command_builder.py
+++ b/tests/test_command_builder.py
@@ -1,6 +1,7 @@
-# tests/test_command_builder.py
-from pathlib import Path
-from ...Engine.Core.command_builder import CommandBuilder
+"""Tests for the command builder."""
+
+from Engine.Core.command_builder import CommandBuilder
+
 
 def test_build_basic(tmp_path):
     b = CommandBuilder(tmp_path)
@@ -8,5 +9,6 @@ def test_build_basic(tmp_path):
     cfg = {"foo": "bar"}
     op = {"script": "echo.py", "args": ["--opt", "{{foo}}"]}
     cmd = b.build("G", games, cfg, op, {})
-    assert cmd[0] in ("python", str(tmp_path/"runtime"/"python3"/"python.exe"))
+    assert cmd[0] in ("python", str(tmp_path / "runtime" / "python3" / "python.exe"))
     assert cmd[2:] == ["--opt", "bar"]
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+"""Tests for Engine configuration loading."""
+
+from Engine.Core.config import EngineConfig
+
+
+def test_load_json_file(tmp_path, capsys):
+    valid = tmp_path / "cfg.json"
+    valid.write_text('{"x": 1}', encoding="utf-8")
+    assert EngineConfig._load_json_file(valid) == {"x": 1}
+
+    invalid = tmp_path / "bad.json"
+    invalid.write_text('{', encoding="utf-8")
+    data = EngineConfig._load_json_file(invalid)
+    assert data == {}
+
+    missing = tmp_path / "missing.json"
+    assert EngineConfig._load_json_file(missing) == {}
+

--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -1,0 +1,10 @@
+"""Tests for placeholder resolution utilities."""
+
+from Engine.Core.placeholders import resolve_placeholders
+
+
+def test_resolve_nested():
+    ctx = {"A": {"B": 1}}
+    assert resolve_placeholders("{{A.B}}", ctx) == "1"
+    assert resolve_placeholders("x{{A.B}}y", ctx) == "x1y"
+

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,51 @@
+"""Tests for tool resolution helpers."""
+"""Tests for tool resolution helpers."""
+
+import json
+import platform
+import sys
+from pathlib import Path
+
+from Engine.Utils.resolver import (
+    _platform_id,
+    _find_executable_under,
+    resolve_tool,
+)
+
+
+def test_platform_id(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    assert _platform_id(False) == "linux-x64"
+    assert _platform_id(True) == "linux-x64-mono"
+
+
+def test_find_executable_under(tmp_path):
+    nested = tmp_path / "dir"
+    nested.mkdir()
+    exe = nested / "tool.sh"
+    exe.write_text("echo")
+    found = _find_executable_under(tmp_path, ["tool.sh"])
+    assert found == exe.resolve()
+
+
+def test_resolve_tool_uses_local_simple_path(tmp_path, monkeypatch):
+    repo = tmp_path
+    (repo / "bin").mkdir()
+    exe = repo / "bin" / "toolx"
+    exe.write_text("")
+    download_dir = repo / "Tools" / "Download"
+    download_dir.mkdir(parents=True)
+    (download_dir / "Tools.json").write_text(
+        json.dumps({"TestTool": {"1.0": {"linux-x64": {"executables": ["toolx"]}}}}),
+        encoding="utf-8",
+    )
+    (download_dir / "Tools.local.json").write_text(
+        json.dumps({"TestTool": {"exe": "bin/toolx"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    resolved = resolve_tool(str(repo), "TestTool")
+    assert resolved == str(exe.resolve())
+


### PR DESCRIPTION
## Summary
- ensure tests can import the `Engine` package
- cover placeholder resolution and command building
- add tests for JSON config loading and tool resolver helpers

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68aab9fea8c883309c57e779e354c0b8