### PR TITLE
refactor tests to use shared utilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+from .test_utils import pytest  # noqa: F401
+
 # Ensure the repository root is on sys.path so ``Engine`` can be imported
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:

--- a/tests/test_command_builder.py
+++ b/tests/test_command_builder.py
@@ -1,5 +1,7 @@
 """Tests for the command builder."""
 
+from .test_utils import pytest
+
 from Engine.Core.command_builder import CommandBuilder
 
 
@@ -11,4 +13,10 @@ def test_build_basic(tmp_path):
     cmd = b.build("G", games, cfg, op, {})
     assert cmd[0] in ("python", str(tmp_path / "runtime" / "python3" / "python.exe"))
     assert cmd[2:] == ["--opt", "bar"]
+
+
+def test_build_requires_game(tmp_path):
+    b = CommandBuilder(tmp_path)
+    with pytest.raises(ValueError):
+        b.build("", {}, {}, {}, {})
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,18 +1,21 @@
 """Tests for Engine configuration loading."""
 
+from .test_utils import pytest
+
 from Engine.Core.config import EngineConfig
 
 
-def test_load_json_file(tmp_path, capsys):
-    valid = tmp_path / "cfg.json"
-    valid.write_text('{"x": 1}', encoding="utf-8")
-    assert EngineConfig._load_json_file(valid) == {"x": 1}
+@pytest.mark.parametrize(
+    "content, expected",
+    [("{\"x\": 1}", {"x": 1}), ("{", {})],
+)
+def test_load_json_file(tmp_path, content, expected):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(content, encoding="utf-8")
+    assert EngineConfig._load_json_file(cfg) == expected
 
-    invalid = tmp_path / "bad.json"
-    invalid.write_text('{', encoding="utf-8")
-    data = EngineConfig._load_json_file(invalid)
-    assert data == {}
 
+def test_load_json_file_missing(tmp_path):
     missing = tmp_path / "missing.json"
     assert EngineConfig._load_json_file(missing) == {}
 

--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -1,10 +1,15 @@
 """Tests for placeholder resolution utilities."""
 
+from .test_utils import pytest
+
 from Engine.Core.placeholders import resolve_placeholders
 
 
-def test_resolve_nested():
+@pytest.mark.parametrize(
+    "template, expected",
+    [("{{A.B}}", "1"), ("x{{A.B}}y", "x1y")],
+)
+def test_resolve_nested(template, expected):
     ctx = {"A": {"B": 1}}
-    assert resolve_placeholders("{{A.B}}", ctx) == "1"
-    assert resolve_placeholders("x{{A.B}}y", ctx) == "x1y"
+    assert resolve_placeholders(template, ctx) == expected
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -5,18 +5,19 @@ import platform
 import sys
 from pathlib import Path
 
-from Engine.Utils.resolver import (
-    _platform_id,
-    _find_executable_under,
-    resolve_tool,
+from .test_utils import pytest
+
+from Engine.Utils.resolver import _find_executable_under, _platform_id, resolve_tool
+
+
+@pytest.mark.parametrize(
+    "use_mono, expected",
+    [(False, "linux-x64"), (True, "linux-x64-mono")],
 )
-
-
-def test_platform_id(monkeypatch):
+def test_platform_id(monkeypatch, use_mono, expected):
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(platform, "machine", lambda: "x86_64")
-    assert _platform_id(False) == "linux-x64"
-    assert _platform_id(True) == "linux-x64-mono"
+    assert _platform_id(use_mono) == expected
 
 
 def test_find_executable_under(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,3 +2,5 @@
 import typing
 import pytest
 
+__all__ = ["typing", "pytest"]
+


### PR DESCRIPTION
## Summary
- import shared `test_utils` in all tests and expose common helpers
- add new coverage for command builder errors
- parameterize tests and ensure pytest usage throughout the suite

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac09f85f08330a5f82cbe5b0f72c1