### PR TITLE
Add tests for CLI and GUI run flows

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,81 @@
+import builtins
+import Engine.cli as cli
+
+
+def _make_select(responses):
+    iterator = iter(responses)
+
+    def fake_select(*args, **kwargs):
+        class Prompt:
+            def ask(self_inner):
+                return next(iterator)
+        return Prompt()
+    return fake_select
+
+
+def _make_text(responses):
+    iterator = iter(responses)
+
+    def fake_text(*args, **kwargs):
+        class Prompt:
+            def ask(self_inner):
+                return next(iterator)
+        return Prompt()
+    return fake_text
+
+
+def test_run_exits_when_no_selection(monkeypatch):
+    class StubEngine:
+        def __init__(self, path):
+            self.calls = 0
+            StubEngine.instance = self
+
+        def get_available_games(self):
+            self.calls += 1
+            return []
+
+    monkeypatch.setattr(cli, "OperationsEngine", StubEngine)
+    monkeypatch.setattr(cli.questionary, "select", _make_select([None]))
+    monkeypatch.setattr(builtins, "input", lambda *a, **kw: "")
+
+    cli.run()
+
+    assert StubEngine.instance.calls == 1
+
+
+def test_run_downloads_custom_module(monkeypatch):
+    class StubEngine:
+        def __init__(self, path):
+            self.downloaded_url = None
+            StubEngine.instance = self
+
+        def get_available_games(self):
+            return []
+
+        def is_git_installed(self):
+            return True
+
+        def get_registered_modules(self):
+            return {"Example": {"url": "https://example.com/repo.git"}}
+
+        def download_module(self, url):
+            self.downloaded_url = url
+
+    monkeypatch.setattr(cli, "OperationsEngine", StubEngine)
+    monkeypatch.setattr(
+        cli.questionary,
+        "select",
+        _make_select([
+            "Download new module...",
+            "Other (Custom URL)...",
+            "Exit",
+        ]),
+    )
+    monkeypatch.setattr(
+        cli.questionary, "text", _make_text(["https://custom.com/repo.git"])
+    )
+    monkeypatch.setattr(builtins, "input", lambda *a, **kw: "")
+
+    cli.run()
+
+    assert StubEngine.instance.downloaded_url == "https://custom.com/repo.git"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,53 @@
+import Engine.gui as gui
+from unittest.mock import MagicMock
+
+
+def test_run_invokes_mainloop(monkeypatch):
+    fake_app = MagicMock()
+    fake_class = MagicMock(return_value=fake_app)
+    monkeypatch.setattr(gui, "RemakeEngineGui", fake_class)
+
+    gui.run()
+
+    fake_class.assert_called_once_with()
+    fake_app.mainloop.assert_called_once_with()
+
+
+def _make_app(monkeypatch, engine):
+    def fake_init(self):
+        self.engine = engine
+        self._console_write = MagicMock()
+    monkeypatch.setattr(gui.RemakeEngineGui, "__init__", fake_init)
+    return gui.RemakeEngineGui()
+
+
+def test_download_module_missing_url(monkeypatch):
+    class StubEngine:
+        def is_git_installed(self):
+            return True
+    engine = StubEngine()
+    app = _make_app(monkeypatch, engine)
+
+    show_error = MagicMock()
+    monkeypatch.setattr(gui.messagebox, "showerror", show_error)
+
+    app._download_module("")
+
+    show_error.assert_called_once()
+    assert "No Git URL" in show_error.call_args[0][1]
+
+
+def test_download_module_requires_git(monkeypatch):
+    class StubEngine:
+        def is_git_installed(self):
+            return False
+    engine = StubEngine()
+    app = _make_app(monkeypatch, engine)
+
+    show_error = MagicMock()
+    monkeypatch.setattr(gui.messagebox, "showerror", show_error)
+
+    app._download_module("https://example.com/repo.git")
+
+    show_error.assert_called_once()
+    assert "Git is not installed" in show_error.call_args[0][1]


### PR DESCRIPTION
## Summary
- add tests exercising Engine.cli.run exit flow and module download path
- add GUI tests verifying run() calls mainloop and _download_module handles error cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae9958b1883308b3e18ee14dc9e0b